### PR TITLE
Change of domains to viessmann-climatesolutions.com

### DIFF
--- a/src/Oauth/ViessmannOauthClientImpl.php
+++ b/src/Oauth/ViessmannOauthClientImpl.php
@@ -31,9 +31,9 @@ class ViessmannOauthClientImpl implements ViessmannOauthClient
      * ViessmannOauthClient constructor.
      * @param $viessmannOauthService
      */
-    const BASE_URL = 'https://api.viessmann.com/iot/v1/';
+    const BASE_URL = 'https://api.viessmann-climatesolutions.com/iot/v1/';
 
-    const HTTPS_IAM_VIESSMANN_COM_IDP_V_1_AUTHORIZE = 'https://iam.viessmann.com/idp/v2/authorize';
+    const HTTPS_IAM_VIESSMANN_COM_IDP_V_1_AUTHORIZE = 'https://iam.viessmann-climatesolutions.com/idp/v2/authorize';
 
     const REDIRECT_URL = "http://localhost:4200/";
 

--- a/src/Oauth/ViessmannOauthService.php
+++ b/src/Oauth/ViessmannOauthService.php
@@ -18,8 +18,8 @@ final class ViessmannOauthService extends AbstractService
 {
 
     const SCOPE_USAGE_GET = 'IoT%20User';
-    private $authorizeURL = 'https://iam.viessmann.com/idp/v2/authorize';
-    private $token_url = 'https://iam.viessmann.com/idp/v2/token';
+    private $authorizeURL = 'https://iam.viessmann-climatesolutions.com/idp/v2/authorize';
+    private $token_url = 'https://iam.viessmann-climatesolutions.com/idp/v2/token';
     protected $redirect_uri = "http://localhost:4200/";
 
     /**


### PR DESCRIPTION
Viessman informed me via e-mail that they will change their domains from viessmann.com to viessmann-climatesolutions.com. For integration, they request the following updates:

1. API Endpoints:
The base URI for all API calls is changing. You need to update your code to use the new domain.
Old: https://​api.​viessmann.​com/...
New: https://​api.​viessmann-climatesolutions.​com/...
2. Identity and Access Management (IAM):
The domain for our identity services will also be updated. This needs to be updated in your application to ensure authorization continues to function correctly.
Old: https://​iam.​viessmann.​com
New: https://​iam.​viessmann-climatesolutions.​com
3. API Response Body:
The uri value within the JSON response from the Features API (/iot/v2/features/...) will reflect the new viessmann​-​climatesolutions.​com domain in the future.

Viessmann has already launched the new domains, so the change can already be applied. The changes suggested in this pull request seem to have done the job for me. At least, my applications are still working with a `Viessmann-Api-2.1.1.phar` that uses the new domains. I have not tested if the applications still work when the old domain is deactivated. Please let me know if I forgot to update something.